### PR TITLE
Bring the option "virtual_voice_stream" back

### DIFF
--- a/src/droid/module-droid-card.c
+++ b/src/droid/module-droid-card.c
@@ -82,7 +82,8 @@ PA_MODULE_USAGE(
         "deferred_volume=<synchronize software and hardware volume changes to avoid momentary jumps?> "
         "config=<location for droid audio configuration> "
         "voice_property_key=<proplist key searched for sink-input that should control voice call volume> "
-        "voice_property_value=<proplist value for the key for voice control sink-input>"
+        "voice_property_value=<proplist value for the key for voice control sink-input> "
+        "voice_virtual_stream=<true/false> create virtual stream for voice call volume control (default false)"
 );
 
 static const char* const valid_modargs[] = {
@@ -103,6 +104,7 @@ static const char* const valid_modargs[] = {
     "config",
     "voice_property_key",
     "voice_property_value",
+    "voice_virtual_stream",
     NULL,
 };
 

--- a/src/droid/module-droid-sink.c
+++ b/src/droid/module-droid-sink.c
@@ -60,6 +60,7 @@ static const char* const valid_modargs[] = {
     "deferred_volume",
     "voice_property_key",
     "voice_property_value",
+    "voice_virtual_stream",
     NULL,
 };
 


### PR DESCRIPTION
This pull request tries to re-patch the recent version of pulseaudio-modules-droid with Canonical's virtual_voice_stream patch. This, together with ubports/pulseaudio-packaging#1, should make audio works when using Halium 7.1-based port without further port-specific modification. It should also help with voice volume control (in combination with ubports/android-headers#6 which fix floating-point function ABI).

Depends on ubports/android-headers#6.