### PR TITLE
Bring back SCO fakesink patch

### DIFF
--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -99,6 +99,8 @@ struct userdata {
     pa_droid_card_data *card_data;
     pa_droid_hw_module *hw_module;
     struct audio_stream_out *stream_out;
+
+    struct pa_sink *sco_fake_sink;
 };
 
 enum {
@@ -123,6 +125,10 @@ typedef struct droid_parameter_mapping {
  * sink-input's absolute volume is used for HAL voice volume. */
 #define DEFAULT_VOICE_CONTROL_PROPERTY_KEY      "media.role"
 #define DEFAULT_VOICE_CONTROL_PROPERTY_VALUE    "phone"
+
+/* Name of the fake sco sink used for HSP (used to set transport property) */
+#define DEFAULT_SCO_FAKE_SINK "sink.fake.sco"
+#define HSP_PREVENT_SUSPEND_STR "bluetooth.hsp.prevent.suspend.transport"
 
 static void parameter_free(droid_parameter_mapping *m);
 static void userdata_free(struct userdata *u);
@@ -185,6 +191,19 @@ static bool remove_extra_devices(struct userdata *u, audio_devices_t devices) {
     }
 
     return need_update;
+}
+
+static void set_fake_sco_sink_transport_property(struct userdata *u, const char *value) {
+    pa_proplist *pl;
+
+    pa_assert(u);
+    pa_assert(value);
+    pa_assert(u->sco_fake_sink);
+
+    pl = pa_proplist_new();
+    pa_proplist_sets(pl, HSP_PREVENT_SUSPEND_STR, value);
+    pa_sink_update_proplist(u->sco_fake_sink, PA_UPDATE_REPLACE, pl);
+    pa_proplist_free(pl);
 }
 
 /* Called from main context during voice calls, and from IO context during media operation. */
@@ -517,6 +536,7 @@ static int sink_process_msg(pa_msgobject *o, int code, void *data, int64_t offse
 static int sink_set_port_cb(pa_sink *s, pa_device_port *p) {
     struct userdata *u = s->userdata;
     pa_droid_port_data *data;
+    const char *sco_transport_enabled;
 
     pa_assert(u);
     pa_assert(p);
@@ -534,6 +554,17 @@ static int sink_set_port_cb(pa_sink *s, pa_device_port *p) {
     pa_log_debug("Sink set port %u", data->device);
 
     set_primary_devices(u, data->device);
+
+    /* Update the bluetooth hsp transport property before we do the routing */
+    if (u->sco_fake_sink) {
+        sco_transport_enabled = pa_proplist_gets(u->sco_fake_sink->proplist, HSP_PREVENT_SUSPEND_STR);
+        if (sco_transport_enabled && pa_streq(sco_transport_enabled, "true")) {
+            if (data->device & ~AUDIO_DEVICE_OUT_ALL_SCO)
+                set_fake_sco_sink_transport_property(u, "false");
+        } else if (data->device & AUDIO_DEVICE_OUT_ALL_SCO)
+            set_fake_sco_sink_transport_property(u, "true");
+    }
+
     /* If we are in voice call, sink is usually in suspended state and routing change can be applied immediately.
      * When in media use cases, do the routing change in IO thread if we are currently in RUNNING or IDLE state. */
     if (u->use_voice_volume || !PA_SINK_IS_OPENED(pa_sink_get_state(u->sink)))
@@ -852,6 +883,25 @@ static pa_hook_result_t sink_proplist_changed_hook_cb(pa_core *c, pa_sink *sink,
     return PA_HOOK_OK;
 }
 
+static struct pa_sink *pa_sco_fake_sink_discover(pa_core *core, const char *sink_name) {
+    struct pa_sink *sink;
+    pa_idxset *idxset;
+    void *state = NULL;
+
+    pa_assert(core);
+    pa_assert(sink_name);
+    pa_assert_se((idxset = core->sinks));
+
+    while ((sink = pa_idxset_iterate(idxset, &state, NULL)) != NULL) {
+        if (pa_streq(sink_name, sink->name)) {
+            pa_log_debug("Found fake SCO sink '%s'", sink_name);
+            return sink;
+        }
+    }
+
+    return NULL;
+}
+
 pa_sink *pa_droid_sink_new(pa_module *m,
                              pa_modargs *ma,
                              const char *driver,
@@ -938,6 +988,7 @@ pa_sink *pa_droid_sink_new(pa_module *m,
                                         NULL, (pa_free_cb_t) parameter_free);
     u->voice_property_key   = pa_xstrdup(pa_modargs_get_value(ma, "voice_property_key", DEFAULT_VOICE_CONTROL_PROPERTY_KEY));
     u->voice_property_value = pa_xstrdup(pa_modargs_get_value(ma, "voice_property_value", DEFAULT_VOICE_CONTROL_PROPERTY_VALUE));
+    u->sco_fake_sink = pa_sco_fake_sink_discover(u->core, pa_modargs_get_value(ma, "sco_fake_sink", DEFAULT_SCO_FAKE_SINK));
     u->extra_devices_map = pa_hashmap_new(pa_idxset_trivial_hash_func, pa_idxset_trivial_compare_func);
 
     if (card_data) {

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -100,6 +100,7 @@ struct userdata {
     pa_droid_hw_module *hw_module;
     struct audio_stream_out *stream_out;
 
+    char *sco_fake_sink_name;
     struct pa_sink *sco_fake_sink;
 };
 
@@ -133,6 +134,7 @@ typedef struct droid_parameter_mapping {
 static void parameter_free(droid_parameter_mapping *m);
 static void userdata_free(struct userdata *u);
 static void set_voice_volume(struct userdata *u, pa_sink_input *i);
+static struct pa_sink *pa_sco_fake_sink_discover(pa_core *core, const char *sink_name);
 
 static void set_primary_devices(struct userdata *u, audio_devices_t devices) {
     pa_assert(u);
@@ -554,6 +556,10 @@ static int sink_set_port_cb(pa_sink *s, pa_device_port *p) {
     pa_log_debug("Sink set port %u", data->device);
 
     set_primary_devices(u, data->device);
+
+    /* See if the sco fake sink element is available (only when needed) */
+    if ((u->sco_fake_sink == NULL) && (data->device & AUDIO_DEVICE_OUT_ALL_SCO))
+        u->sco_fake_sink = pa_sco_fake_sink_discover(u->core, u->sco_fake_sink_name);
 
     /* Update the bluetooth hsp transport property before we do the routing */
     if (u->sco_fake_sink) {
@@ -988,7 +994,7 @@ pa_sink *pa_droid_sink_new(pa_module *m,
                                         NULL, (pa_free_cb_t) parameter_free);
     u->voice_property_key   = pa_xstrdup(pa_modargs_get_value(ma, "voice_property_key", DEFAULT_VOICE_CONTROL_PROPERTY_KEY));
     u->voice_property_value = pa_xstrdup(pa_modargs_get_value(ma, "voice_property_value", DEFAULT_VOICE_CONTROL_PROPERTY_VALUE));
-    u->sco_fake_sink = pa_sco_fake_sink_discover(u->core, pa_modargs_get_value(ma, "sco_fake_sink", DEFAULT_SCO_FAKE_SINK));
+    u->sco_fake_sink_name = pa_xstrdup(pa_modargs_get_value(ma, "sco_fake_sink", DEFAULT_SCO_FAKE_SINK));
     u->extra_devices_map = pa_hashmap_new(pa_idxset_trivial_hash_func, pa_idxset_trivial_compare_func);
 
     if (card_data) {
@@ -1275,6 +1281,9 @@ static void userdata_free(struct userdata *u) {
 
     if (u->hw_module)
         pa_droid_hw_module_unref(u->hw_module);
+
+    if (u->sco_fake_sink_name)
+        pa_xfree(u->sco_fake_sink_name);
 
     if (u->voice_property_key)
         pa_xfree(u->voice_property_key);

--- a/src/droid/module-droid-sink.c
+++ b/src/droid/module-droid-sink.c
@@ -45,7 +45,8 @@
 PA_MODULE_AUTHOR("Juho Hämäläinen");
 PA_MODULE_DESCRIPTION("Droid sink");
 PA_MODULE_USAGE("master_sink=<sink to connect to> "
-                "sink_name=<name of created sink>");
+                "sink_name=<name of created sink> "
+                "sco_fake_sink=<name of the fake sco sink used for hsp>");
 PA_MODULE_VERSION(PACKAGE_VERSION);
 
 static const char* const valid_modargs[] = {
@@ -60,6 +61,7 @@ static const char* const valid_modargs[] = {
     "deferred_volume",
     "voice_property_key",
     "voice_property_value",
+    "sco_fake_sink",
     NULL,
 };
 


### PR DESCRIPTION
This commit forward-port Canonical's SCO fakesink patch. This should make it possible to place a call over a Bluetooth headset for Halium 7.1 based ports.