### PR TITLE
[extevdev] make the combo port always available (Android 7)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,68 +1,7 @@
-String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
-String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
+@Library('ubports-build-tools') _
 
-pipeline {
-  agent any
-  stages {
-    stage('Build source') {
-      steps {
-        sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: stashFileList)
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-    stage('Build binary - armhf') {
-      steps {
-        parallel(
-          "Build binary - armhf": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="armhf"
-build-binary.sh'''
-              stash(includes: stashFileList, name: 'build-armhf')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
+buildAndProvideDebianPackage()
 
-
-          },
-          "Build binary - arm64": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="arm64"
-    build-binary.sh'''
-              stash(includes: stashFileList, name: 'build-arm64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          },
-          "Build binary - amd64": {
-            node(label: 'amd64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="amd64"
-    build-binary.sh'''
-              stash(includes: stashFileList, name: 'build-amd64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          }
-        )
-      }
-    }
-    stage('Results') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        unstash 'build-armhf'
-        unstash 'build-arm64'
-        unstash 'build-amd64'
-        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
-        sh '''/usr/bin/build-repo.sh'''
-      }
-    }
-    stage('Cleanup') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-  }
-}
+// Or if the package consists entirely of arch-independent packages:
+// (optional optimization, will confuse BlueOcean's live view at build stage)
+// buildAndProvideDebianPackage(/* isArchIndependent */ true)

--- a/src/droid/droid-extevdev.c
+++ b/src/droid/droid-extevdev.c
@@ -113,7 +113,6 @@ static struct libevdev *find_switch_evdev(void) {
  * become available, so the last port available will stay active. */
 
 static const char *headphone_ports[] = {
-    "output-speaker+wired_headphone",
     "output-wired_headphone",
 };
 


### PR DESCRIPTION
Ringtone & alarm uses the combo port to play to both the headphone and
the speaker. But because we distinguish between headphone and headset,
the port won't be available if we plug a headset with a mic.

Turns out, droid-extcon doesn't do the availability thing on this port,
so the port is always available. So, we should do the same.

This PR comes with Jenkinsfile update, which is not strictly necessary (because the old one already archives .ddeb's), but allows the Jenkins pipeline master thing to be used.