### PR TITLE
droid-sink: Introduce HAL-backed voice volume adjustment

### DIFF
--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -865,7 +865,7 @@ void pa_droid_sink_set_voice_control(pa_sink* sink, bool enable) {
 
         pa_assert(!u->sink_input_volume_changed_hook_slot);
 
-        if (u->use_hw_volume && u->use_hw_voice_volume)
+        if (u->use_hw_voice_volume)
             pa_sink_set_set_volume_callback(u->sink, sink_set_voice_volume_cb);
         else if (u->use_hw_volume)
             pa_sink_set_set_volume_callback(u->sink, NULL);
@@ -891,7 +891,7 @@ void pa_droid_sink_set_voice_control(pa_sink* sink, bool enable) {
         pa_log_debug("Using %s volume control with %s",
                      u->use_hw_volume ? "hardware" : "software", u->sink->name);
 
-        if (u->use_hw_volume)
+        if (u->use_hw_volume || u->use_hw_voice_volume)
             pa_sink_set_set_volume_callback(u->sink, sink_set_volume_cb);
     }
 }

--- a/src/droid/droid-sink.c
+++ b/src/droid/droid-sink.c
@@ -666,10 +666,9 @@ static void update_volumes(struct userdata *u) {
         pa_log_debug("Using %s volume control with %s",
                      u->use_hw_volume ? "hardware" : "software", u->sink->name);
     }
-    if (u->use_hw_voice_volume) {
-        pa_log_debug("Using %s voice volume control with %s",
-                     u->use_hw_voice_volume ? "hardware" : "software", u->sink->name);
-    }
+
+    pa_log_debug("Using %s voice volume control with %s",
+                 u->use_hw_voice_volume ? "hardware" : "software", u->sink->name);
 
     if (u->use_hw_volume)
         pa_sink_set_set_volume_callback(u->sink, sink_set_volume_cb);


### PR DESCRIPTION
The Android HAL can be instructed to set the voice volume rather than relying on the
virtual voice stream, which may not work on all devices. Do this by probing the capability
at runtime and setting the corresponding callback function for when volume is desired to be adjusted.